### PR TITLE
feat(user): added onboarding fields to User entity and CreateUserDto

### DIFF
--- a/backend/src/users/dtos/createUserDto.ts
+++ b/backend/src/users/dtos/createUserDto.ts
@@ -5,10 +5,16 @@ import {
   IsOptional,
   MaxLength,
   Matches,
+  IsArray,
+  ArrayNotEmpty,
 } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger'
 import { Transform } from 'class-transformer';
 import { userRole } from '../enums/userRole.enum';
+import { ChallengeLevel } from '../enums/challengeLevel.enum';
+import { ChallengeType } from '../enums/challengeType.enum';
+import { ReferralSource } from '../enums/referralSource.enum';
+import { AgeGroup } from '../enums/ageGroup.enum';
 import { AuthProvider } from '../../auth/enum/authProvider.enum';
 
 export class CreateUserDto {
@@ -120,4 +126,37 @@ export class CreateUserDto {
   @IsOptional()
   @MaxLength(225)
   googleId?: string;
+
+  @ApiProperty({
+    enum: ChallengeLevel,
+    example: ChallengeLevel.INTERMEDIATE,
+  })
+  @IsEnum(ChallengeLevel)
+  challengeLevel: ChallengeLevel;
+
+  @ApiProperty({
+    enum: ChallengeType,
+    isArray: true,
+    example: [ChallengeType.CODING, ChallengeType.LOGIC],
+  })
+  @IsArray()
+  @ArrayNotEmpty()
+  @IsEnum(ChallengeType, { each: true })
+  challengeTypes: ChallengeType[];
+
+  @ApiProperty({
+    enum: ReferralSource,
+    example: ReferralSource.GOOGLE,
+    required: false,
+  })
+  @IsOptional()
+  @IsEnum(ReferralSource)
+  referralSource?: ReferralSource;
+
+  @ApiProperty({
+    enum: AgeGroup,
+    example: AgeGroup.YOUNG_ADULT,
+  })
+  @IsEnum(AgeGroup)
+  ageGroup: AgeGroup;
 }

--- a/backend/src/users/enums/ageGroup.enum.ts
+++ b/backend/src/users/enums/ageGroup.enum.ts
@@ -1,0 +1,9 @@
+export enum AgeGroup {
+  TEENS = '10-17 years old',
+  YOUNG_ADULT = '18-24 years old',
+  ADULT = '25-34 years old',
+  MID_AGE = '35-44 years old',
+  FORTIES = '45-54 years old',
+  FIFTIES = '55-64 years old',
+  SENIOR = '65+ years old',
+}

--- a/backend/src/users/enums/challengeLevel.enum.ts
+++ b/backend/src/users/enums/challengeLevel.enum.ts
@@ -1,0 +1,6 @@
+export enum ChallengeLevel {
+  BEGINNER = 'beginner',
+  INTERMEDIATE = 'intermediate',
+  ADVANCED = 'advanced',
+  EXPERT = 'expert',
+}

--- a/backend/src/users/enums/challengeType.enum.ts
+++ b/backend/src/users/enums/challengeType.enum.ts
@@ -1,0 +1,5 @@
+export enum ChallengeType {
+  CODING = 'Coding Challenges',
+  LOGIC = 'Logic Puzzle',
+  BLOCKCHAIN = 'Blockchain',
+}

--- a/backend/src/users/enums/referralSource.enum.ts
+++ b/backend/src/users/enums/referralSource.enum.ts
@@ -1,0 +1,6 @@
+export enum ReferralSource {
+  GOOGLE = 'Google Search',
+  TWITTER = 'X/Twitter',
+  FRIENDS = 'Friends',
+  OTHER = 'Other',
+}

--- a/backend/src/users/user.entity.ts
+++ b/backend/src/users/user.entity.ts
@@ -9,6 +9,7 @@ import {
   PrimaryGeneratedColumn,
 } from 'typeorm';
 import { userRole } from './enums/userRole.enum';
+import { ChallengeLevel } from './enums/challengeLevel.enum';
 import { LeaderboardEntry } from '../leaderboard/entities/leaderboard.entity';
 import { Badge } from '../badge/entities/badge.entity';
 import { Achievement } from '../achievement/entities/achievement.entity';
@@ -98,6 +99,44 @@ export class User {
   })
   @JoinTable()
   achievements: Achievement[];
+
+
+
+  @ApiProperty({
+    enum: ChallengeLevel,
+    example: ChallengeLevel.INTERMEDIATE,
+    description: 'Challenge level of the user',
+    required: false
+  })
+  @Column({
+    type: 'enum', enum: ChallengeLevel, nullable: true
+  })
+  challengeLevel?: ChallengeLevel;
+
+  @ApiProperty({
+    example: ['Coding Challenges', 'Logic Puzzle'],
+    description: 'Selected challenge types',
+    required: false,
+    isArray: true,
+  })
+  @Column('simple-array', { nullable: true })
+  challengeTypes?: string[];
+
+  @ApiProperty({
+    example: 'Google Search',
+    description: 'Where the user heard about us',
+    required: false,
+  })
+  @Column('varchar', { length: 100, nullable: true })
+  referralSource?: string;
+
+  @ApiProperty({
+    example: '18 to 24 years old',
+    description: 'Age group of the user',
+    required: false,
+  })
+  @Column('varchar', { length: 50, nullable: true })
+  ageGroup?: string;
 
   /**
    * One-to-many relation with puzzle progress records.


### PR DESCRIPTION
- Extended User entity with new nullable fields:
  - challengeLevel (enum)
  - challengeTypes (string[], stored as simple-array)
  - referralSource (string)
  - ageGroup (string)

- Updated CreateUserDto to validate onboarding fields:
  - challengeLevel → must be one of "beginner" | "intermediate" | "advanced" | "expert"
  - challengeTypes → must contain at least one valid challenge type
  - referralSource → optional, but must match allowed sources if provided
  - ageGroup → must match predefined ranges

- Added enums for ChallengeLevel, ChallengeType, ReferralSource, and AgeGroup
- Ensured compatibility with local + Google auth flows (fields nullable at entity level)
